### PR TITLE
Add transform to fix preview when dragging elements

### DIFF
--- a/plugins/lunchbadger-core/src/components/CanvasElements/CanvasElement.scss
+++ b/plugins/lunchbadger-core/src/components/CanvasElements/CanvasElement.scss
@@ -13,6 +13,7 @@
   padding: 0;
   margin: 20px 0;
   transition: all .3s ease;
+  transform: translateZ(0);
 
   &.mouse-over {
     z-index: 1;


### PR DESCRIPTION
Fix for chrome/chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=605119&can=2&start=0&num=100&q=draggable&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Component%20Status%20Owner%20Summary%20OS%20Modified&groupby=&sort=)
